### PR TITLE
Added Packet type for for Transporter.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ lazy val compilerOptions = Seq(
 )
 
 lazy val testDependencies = Seq(
-  "org.scalatest"   %%  "scalatest" % "2.2.6"
+  "org.scalatest"   %%  "scalatest"     % "2.2.6",
+   "org.mockito"    %   "mockito-core"  % "1.10.19"
 )
 
 

--- a/core/src/main/scala/roc/postgresql/transport/Buffer.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Buffer.scala
@@ -1,6 +1,7 @@
 package com.github.finagle
-package transport
 package roc
+package postgresql
+package transport
 
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import java.nio.ByteOrder
@@ -213,9 +214,11 @@ trait BufferWriter extends Buffer {
   def writeLong(n: Long): BufferWriter
   def writeFloat(f: Float): BufferWriter
   def writeDouble(d: Double): BufferWriter
+  def writeNull: BufferWriter
 
   def skip(n: Int): BufferWriter
 
+  def toBytes: Array[Byte]
   /**
    * Fills the rest of the buffer with the given byte.
    * @param b Byte used to fill.
@@ -358,6 +361,17 @@ object BufferWriter {
     def writeBytes(bytes: Array[Byte]) = {
       underlying.writeBytes(bytes)
       this
+    }
+
+    def writeNull: BufferWriter = {
+      underlying.writeZero(1)
+      this
+    }
+
+    def toBytes: Array[Byte] = {
+      val bytes = new Array[Byte](underlying.writerIndex)
+      underlying.getBytes(0, bytes)
+      bytes
     }
   }
 }

--- a/core/src/main/scala/roc/postgresql/transport/Netty3.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Netty3.scala
@@ -1,0 +1,64 @@
+package com.github.finagle
+package roc
+package postgresql
+package transport
+
+import com.twitter.finagle.client.Transporter
+import com.twitter.finagle.netty3.Netty3Transporter
+import com.twitter.util.NonFatal
+import org.jboss.netty.buffer.ChannelBuffer
+import org.jboss.netty.channel._
+import org.jboss.netty.handler.codec.frame.FrameDecoder
+
+private[roc] final class PacketFrameDecoder extends FrameDecoder {
+
+  override def decode(ctx: ChannelHandlerContext, channel: Channel, 
+                      buffer: ChannelBuffer): Packet = {
+    if(buffer.readableBytes < Packet.HeaderSize) return null
+
+    buffer.markReaderIndex()
+    val code = buffer.readByte.toChar
+    val length = buffer.readInt 
+
+    if(buffer.readableBytes < length - 4) {
+      buffer.resetReaderIndex()
+      return null
+    }
+
+    val body = new Array[Byte](length - 4)
+    buffer.readBytes(body)
+    Packet(Some(code), BufferReader(body))
+  }
+
+}
+
+private[roc] final class PacketEncoder extends SimpleChannelDownstreamHandler {
+  override def writeRequested(ctx: ChannelHandlerContext, evt: MessageEvent) =
+    evt.getMessage match {
+      case p: Packet =>
+        try {
+          val cb = p.toChannelBuffer
+          Channels.write(ctx, evt.getFuture, cb, evt.getRemoteAddress)
+        } catch {
+          case NonFatal(e) =>
+            val _ = evt.getFuture.setFailure(new ChannelException(e.getMessage))
+        }
+
+      case unknown =>
+        val _ = evt.getFuture.setFailure(new ChannelException(
+          "Unsupported request type %s".format(unknown.getClass.getName)))
+    }
+}
+
+/**
+  * A Netty3 pipeline that is responsible for framing network traffic in 
+  * terms of of logical postgresql packets ( see Packet )
+ */
+private[roc] object PostgresqlClientPipelineFactory extends ChannelPipelineFactory {
+  def getPipeline = {
+    val pipeline = Channels.pipeline()
+    pipeline.addLast("pgPacketDecoder", new PacketFrameDecoder)
+    pipeline.addLast("pgPacketEncoder", new PacketEncoder)
+    pipeline
+  }
+}

--- a/core/src/main/scala/roc/postgresql/transport/Packet.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Packet.scala
@@ -1,0 +1,32 @@
+package com.github.finagle
+package roc
+package postgresql
+package transport
+
+import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+
+case class Packet(messageType: Option[Char], body: Buffer) {
+
+  def length: Int = body.underlying.capacity + 4
+
+  def toChannelBuffer: ChannelBuffer = {
+    val messageByte = messageType match {
+      case Some(char) => Array[Byte](char.toByte)
+      case None       => Array[Byte]()
+    }
+    val bufferLength = messageByte.length + length
+    val buffer = BufferWriter(new Array[Byte](bufferLength))
+    if(messageByte.length > 0) {
+      buffer.writeBytes(messageByte)
+    }
+    buffer.writeInt(length)
+    buffer.writeBytes(body.underlying.array)
+    ChannelBuffers.wrappedBuffer(buffer.toBytes)
+  }
+
+}
+
+
+object Packet {
+  val HeaderSize = 5
+}

--- a/core/src/test/scala/roc/postgresql/transport/BufferTest.scala
+++ b/core/src/test/scala/roc/postgresql/transport/BufferTest.scala
@@ -1,6 +1,7 @@
 package com.github.finagle
-package transport
 package roc
+package postgresql
+package transport
 
 import org.scalatest.FunSuite
 

--- a/core/src/test/scala/roc/postgresql/transport/PacketFrameDecoderTest.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketFrameDecoderTest.scala
@@ -1,0 +1,34 @@
+package com.github.finagle
+package roc
+package postgresql
+package transport
+
+import org.jboss.netty.buffer.ChannelBuffers
+import org.jboss.netty.channel.{Channel, ChannelHandlerContext}
+import org.scalatest.FunSuite
+import org.scalatest.mock.MockitoSugar
+
+final class PacketFrameDecoderTest extends FunSuite with MockitoSugar {
+  val ctx = mock[ChannelHandlerContext]
+  val c = mock[Channel]
+  val frameDecoder = new PacketFrameDecoder
+
+  test("ignore incomplete packets") {
+    val partial = Array[Byte](0x05, 0x00)
+    val result = frameDecoder.decode(ctx, c, ChannelBuffers.wrappedBuffer(partial))
+    assert(result === null)
+  }
+
+  test("decode complete packets") {
+
+    val messageByte = Array[Byte](0x52)
+    val lengthBytes = Array[Byte](0x0, 0x0, 0x0, 0x8)
+    val okBytes     = Array[Byte](0x0, 0x0, 0x0, 0x0)
+    val bytes       = messageByte ++ lengthBytes ++ okBytes
+
+    val result = frameDecoder.decode(ctx, c, ChannelBuffers.wrappedBuffer(bytes))
+    assert(result != null)
+    assert(result.messageType === Some('R'))
+    assert(result.body.underlying.array === okBytes)
+  }
+}

--- a/core/src/test/scala/roc/postgresql/transport/PacketTest.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketTest.scala
@@ -1,0 +1,42 @@
+package com.github.finagle
+package roc
+package postgresql
+package transport
+
+import org.scalatest.FunSuite
+
+final class PacketTest extends FunSuite {
+
+  test("Encode a Packet") {
+    val messageType = Some('R')
+    val bytes = Array[Byte](0x0,0x0,0x0,0x0)
+    val packet = Packet(messageType, Buffer(bytes))
+
+    val buf = Buffer.fromChannelBuffer(packet.toChannelBuffer)
+    val br = BufferReader(buf)
+    assert(br.readByte === 'R')
+    assert(br.readInt === 8)
+    assert(br.readInt === 0)
+  }
+
+  test("Encode a Packet with no message type") {
+    val messageType       = None
+    val versionBytes      = Array[Byte](0x0, 0x3, 0x0, 0x0, 0x13)
+    val userBytes         = Array[Byte](0x75, 0x73, 0x65, 0x72, 0x0)
+    val testUserBytes     = Array[Byte](0x74, 0x65, 0x73, 0x74, 0x55, 0x73, 0x65, 0x72, 0x0)
+    val databaseBytes     = Array[Byte](0x64, 0x61, 0x74, 0x61, 0x62, 0x61, 0x73, 0x65, 0x0)
+    val databaseNameBytes = Array[Byte](0x74, 0x65, 0x73, 0x74, 0x5F, 0x64, 0x61, 0x74, 0x61, 0x62,
+      0x61, 0x73, 0x65, 0x0)
+    val bytes = versionBytes ++ userBytes ++ testUserBytes ++ databaseBytes ++ databaseNameBytes
+    val packet = Packet(messageType, Buffer(bytes))
+    val buf = Buffer.fromChannelBuffer(packet.toChannelBuffer)
+    val br = BufferReader(buf)
+
+    val _ = br.readInt
+    assert(br.readInt === 196608)
+    assert(br.readNullTerminatedString().trim === "user")
+    assert(br.readNullTerminatedString() === "testUser")
+    assert(br.readNullTerminatedString() === "database")
+    assert(br.readNullTerminatedString() === "test_database")
+  }
+}


### PR DESCRIPTION
The Packet type encodes a standardized Postgresql packet which
represents an exchange between the Postgresql Server and the
Client ( this finagle protocol ).

Added Netty3 pipeline and Packet decoding tests
