### PR TITLE
Introduced Request / Result types.

### DIFF
--- a/core/src/main/scala/roc/postgresql/Client.scala
+++ b/core/src/main/scala/roc/postgresql/Client.scala
@@ -8,19 +8,21 @@ import com.twitter.util.{Closable, Future, Time}
 
 
 object Client {
-  def apply (factory: ServiceFactory[FrontendMessage, Message]): Client = 
+  def apply (factory: ServiceFactory[Request, Result]): Client = 
     new StdClient(factory)
 }
 
 trait Client extends Closable {
-  def query(m: Query): Future[Message]
+  def query(req: Request): Future[Result]
 }
 
-final class StdClient(val factory: ServiceFactory[FrontendMessage, Message]) extends Client {
+final class StdClient(val factory: ServiceFactory[Request, Result]) extends Client {
   private[this] val service = factory.toService
 
-  def query(m: Query): Future[Message] =
-    service(m)
+  def query(req: Request): Future[Result] = {
+    val query = new Query(req.query)
+    service(req)
+  }
 
   def close(deadline: Time): Future[Unit] = service.close(deadline)
 }

--- a/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
+++ b/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
@@ -11,6 +11,8 @@ import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.{CancelledRequestException, Service, WriteException, ServiceProxy}
 import com.twitter.util.{Future, NoFuture, Promise, Return, Try, Throw}
 
+import scala.collection.mutable.ListBuffer
+
 import java.util.concurrent.atomic.AtomicReference
 
 import com.github.finagle.roc.postgresql.transport.Packet
@@ -21,47 +23,76 @@ import cats.data.Xor
 
 final class ClientDispatcher(trans: Transport[Packet, Packet],
   startup: Startup)
-  extends GenSerialClientDispatcher[FrontendMessage, Message, Packet, Packet](trans) {
+  extends GenSerialClientDispatcher[Request, Result, Packet, Packet](trans) {
   import ClientDispatcher._
 
   private[this] val state = new AtomicReference[Future[_]](Off)
 
-  private[this] var backendKey: Option[BackendKeyData] = None
+  private[this] var backendKeyData: Option[BackendKeyData] = None
   private[this] var ps: List[ParameterStatusMessage] = Nil
 
-  override def apply(req: FrontendMessage): Future[Message] = state.get match {
-    case Off => {
-      state.set(On)
-      startupPhase.flatMap { _ => super.apply(req) }
+  override def apply(req: Request): Future[Result] =
+    state.get match {
+      case Off => for {
+        _     <-  authenticate
+        _     <-  completeStartup
+        resp  <-  super.apply(req)
+      } yield resp
+      case On => super.apply(req)
     }
-    case On => super.apply(req)
-  }
 
-  val startupPhase: Future[Message] = {
+  def exchange(fm: FrontendMessage): Future[Message] = trans.write(fm.encode)
+    .rescue(wrapWriteException)
+    .before {
+      trans.read().flatMap(decodePacket(_))
+    }
+
+  def authenticate: Future[Unit] = {
     val sm = StartupMessage(startup.username, startup.database)
-    super.apply(sm)
+    exchange(sm)
       .flatMap(message => message match {
-        case AuthenticationOk => Future.value(message)
+        case AuthenticationOk => Future.Done //Future.value(message)
         case AuthenticationClearTxtPasswd => {
-          super.apply(new PasswordMessage(startup.password))
+          exchange(new PasswordMessage(startup.password))
             .flatMap(response => response match {
-              case AuthenticationOk => Future.value(response)
-              case ReadyForQuery('I') => Future.value(response)
+              case AuthenticationOk => Future.Done // Future.value(response)
+              case ReadyForQuery('I') => Future.Done // Future.value(response)
               case _ => Future.exception(new Exception())
             })
         }
         case AuthenticationMD5Passwd(salt) => {
           val encryptedPasswd = PasswordMessage.encryptMD5Passwd(startup.username, 
             startup.password, salt)
-          super.apply(new PasswordMessage(encryptedPasswd))
+          exchange(new PasswordMessage(encryptedPasswd))
             .flatMap(response => response match {
-              case AuthenticationOk => Future.value(response)
-              case ReadyForQuery('I') => Future.value(response)
+              case AuthenticationOk => Future.Done // Future.value(response)
+              case ReadyForQuery('I') => Future.Done // Future.value(response)
               case _ => Future.exception(new Exception())
             })
         }
-        case ReadyForQuery('I') => Future.value(message)
+        case ReadyForQuery('I') => Future.Done // Future.value(message)
         case r => println(r); Future.exception(new Exception())
+      })
+  }
+
+  def completeStartup: Future[Unit] = {
+
+    def go(xs: List[ParameterStatusMessage], ys: List[BackendKeyData]):
+      Future[(List[ParameterStatusMessage], List[BackendKeyData])] = trans.read()
+      .flatMap{ packet => decodePacket(packet).flatMap{ msg => msg match {
+        case p: ParameterStatusMessage => go(p :: xs, ys)
+        case bkd: BackendKeyData       => go(xs, bkd :: ys)
+        case ReadyForQuery('I')        => Future.value((xs, ys))
+        case _ => Future.exception(new Exception())
+      }}
+    }
+
+    go(List.empty[ParameterStatusMessage], List.empty[BackendKeyData])
+      .flatMap(tuple => {
+        ps = tuple._1
+        backendKeyData = tuple._2.headOption
+        state.set(On)
+        Future.Done
       })
   }
 
@@ -72,49 +103,38 @@ final class ClientDispatcher(trans: Transport[Packet, Packet],
    * is decoupled from the promise that signals a complete exchange.
    * This leaves room for implementing streaming results.
    */
-  override protected def dispatch(req: FrontendMessage, rep: Promise[Message]): Future[Unit] = {
-    trans.write(req.encode) rescue {
+  override protected def dispatch(req: Request, rep: Promise[Result]): Future[Unit] = {
+    val query = new Query(req.query)
+    trans.write(query.encode) rescue {
       wrapWriteException
     } before {
       val signal = new Promise[Unit]
-      rep.become(drainTransport(req, signal))
+      rep.become(drainTransport(query, signal))
       signal
     }
   }
 
-  private def drainTransport(req: FrontendMessage, signal: Promise[Unit]): Future[Message] = {
-    def go(signal: Promise[Unit]): Future[Message] = trans.read() flatMap { packet => 
-      decodePacket(packet) flatMap { message => 
-        req match {
-          case s: StartupMessage => message match {
-            case AuthenticationClearTxtPasswd => signal.setDone(); Future.value(message)
-            case AuthenticationMD5Passwd(_) => signal.setDone(); Future.value(message)
-            case AuthenticationOk => go(signal)
-            case p: ParameterStatusMessage => ps :+ p; go(signal)
-            case bkd: BackendKeyData => backendKey = Some(bkd); go(signal)
-            case ReadyForQuery('I') => signal.setDone(); Future.value(message)
-            case r => println(r); Future.exception(new Exception())
-          }
-          case pm: PasswordMessage => message match {
-            case AuthenticationOk => go(signal)
-            case p: ParameterStatusMessage => ps :+ p; go(signal)
-            case bkd: BackendKeyData => backendKey = Some(bkd); go(signal)
-            case ReadyForQuery('I') => signal.setDone(); Future.value(message)
-            case r => println(r); Future.exception(new Exception())
-          }
+  private def drainTransport(req: FrontendMessage, signal: Promise[Unit]): Future[Result] = {
+
+    def go(xs: List[RowDescription], ys: List[DataRow]): 
+      Future[(List[RowDescription], List[DataRow])] = trans.read()
+        .flatMap { packet => decodePacket(packet)
+          .flatMap { message => req match {
           case q: Query => message match {
-            case rd: RowDescription => println(rd); go(signal)
-            case dr: DataRow => println(dr); go(signal)
-            case cc: CommandComplete => println(cc); go(signal)
-            case ReadyForQuery('I') => println("all done"); signal.setDone(); Future.value(message)
-            case _ => Future.exception(new Exception())
+            case rd: RowDescription => go(rd :: xs, ys)
+            case dr: DataRow => go(xs, dr :: ys)
+            case cc: CommandComplete => go(xs, ys)
+            case ReadyForQuery('I') => signal.setDone(); Future.value((xs, ys))
+            case r => println(s"Got $r"); Future.exception(new Exception())
           }
           case _ => Future.exception(new Exception())
           }
         }
       }
 
-    go(signal)
+      go(List.empty[RowDescription], List.empty[DataRow]).map( tuple => {
+        new Result(tuple._1.head, tuple._2)
+      })
   }
 
   private[this] def decodePacket(packet: Packet): Future[Message] = packet.messageType match {
@@ -147,6 +167,6 @@ object ClientDispatcher {
     case exc: Throwable => Future.exception(WriteException(exc))
   }
 
-  def apply(trans: Transport[Packet, Packet], startup: Startup): Service[FrontendMessage, Message] =
+  def apply(trans: Transport[Packet, Packet], startup: Startup): Service[Request, Result] =
     new ClientDispatcher(trans, startup)
 }

--- a/core/src/main/scala/roc/postgresql/Request.scala
+++ b/core/src/main/scala/roc/postgresql/Request.scala
@@ -1,0 +1,5 @@
+package com.github.finagle
+package roc
+package postgresql
+
+case class Request(query: String)

--- a/core/src/main/scala/roc/postgresql/Result.scala
+++ b/core/src/main/scala/roc/postgresql/Result.scala
@@ -1,0 +1,5 @@
+package com.github.finagle
+package roc
+package postgresql
+
+case class Result(rowDescription: RowDescription, data: List[DataRow])


### PR DESCRIPTION
Postgres Messages are an implementation detail we will want to keep
away from users. The Postgresql Client now relies on Request and
Result types. A full pass through has been completed, however
the Result type is currently just a wrapper around Postgres
Messages describing the Query result.

Roc is now a Finagle Service (r: Request) => Future[Result] for
working with a Postgresql Database.
