### PR TITLE
Introduced roc-types submodule.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,19 @@ lazy val core =  project
     )
   )
 
+lazy val types = project
+  .settings(moduleName := "roc-types")
+  .settings(version := coreVersion)
+  .settings(allSettings:_*)
+  .settings(docSettings)
+  .settings(sharedPublishSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel"   %%  "cats"  %   catsVersion
+    )
+  )
+  .dependsOn(core)
+
 lazy val benchmark = project
   .settings(
     description := "roc-benchmark",

--- a/core/src/main/scala/roc/postgresql/failures.scala
+++ b/core/src/main/scala/roc/postgresql/failures.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import roc.postgresql.server.PostgresqlMessage
 
 object failures {
-  sealed abstract class Failure extends Exception
+  private[roc] abstract class Failure extends Exception
 
   /** An Error occurring on the Postgresql Server.
     *

--- a/core/src/main/scala/roc/postgresql/transport/Buffer.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Buffer.scala
@@ -6,7 +6,7 @@ import java.nio.ByteOrder
 import java.nio.charset.Charset
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 
-private[postgresql] object Buffer {
+private[roc] object Buffer {
   val NullLength = -1 // denotes a SQL NULL value when reading a length coded binary.
   val EmptyString = new String
 
@@ -30,12 +30,12 @@ private[postgresql] object Buffer {
 
 }
 
-private[postgresql] sealed trait Buffer {
+private[roc] sealed trait Buffer {
   val underlying: ChannelBuffer
   def capacity: Int = underlying.capacity
 }
 
-private[postgresql] trait BufferReader extends Buffer {
+private[roc] trait BufferReader extends Buffer {
 
   /** Current reader offset in the buffer. */
   def offset: Int
@@ -140,7 +140,7 @@ private[postgresql] trait BufferReader extends Buffer {
   def toString(start: Int, length: Int, charset: Charset): String
 }
 
-private[postgresql] object BufferReader {
+private[roc] object BufferReader {
 
   def apply(buf: Buffer, offset: Int = 0): BufferReader = {
     require(offset >= 0, "Invalid reader offset")
@@ -192,7 +192,7 @@ private[postgresql] object BufferReader {
  * that is, all operations increase the offset
  * into the underlying buffer.
  */
-private[postgresql] trait BufferWriter extends Buffer {
+private[roc] trait BufferWriter extends Buffer {
 
   /**
    * Current writer offset.
@@ -296,7 +296,7 @@ private[postgresql] trait BufferWriter extends Buffer {
    }
 }
 
-private[postgresql] object BufferWriter {
+private[roc] object BufferWriter {
 
   def apply(buf: Buffer, offset: Int = 0): BufferWriter = {
     require(offset >= 0, "Inavlid writer offset.")

--- a/types/src/main/scala/roc/types/decoders.scala
+++ b/types/src/main/scala/roc/types/decoders.scala
@@ -1,0 +1,39 @@
+package roc
+package types
+
+import cats.data.Xor
+import roc.postgresql.ElementDecoder
+import roc.types.failures._
+import roc.postgresql.transport.BufferReader
+
+object decoders {
+
+  implicit def optionElementDecoder[A](implicit f: ElementDecoder[A]) = 
+    new ElementDecoder[Option[A]] {
+      def textDecoder(text: String): Option[A]         = Some(f.textDecoder(text))
+      def binaryDecoder(bytes: Array[Byte]): Option[A] = Some(f.binaryDecoder(bytes))
+      def nullDecoder(): Option[A]                     = None
+    }
+
+  implicit val stringElementDecoder: ElementDecoder[String] = new ElementDecoder[String] {
+    def textDecoder(text: String): String         = text
+    def binaryDecoder(bytes: Array[Byte]): String = bytes.map(_.toChar).mkString
+    def nullDecoder(): String                     = throw new NullDecodedFailure("STRING")
+  }
+
+  implicit val intElementDecoder: ElementDecoder[Int] = new ElementDecoder[Int] {
+    def textDecoder(text: String): Int         = Xor.catchNonFatal(
+      text.toInt
+    ).fold(
+      {l => throw new ElementDecodingFailure("INT", l)},
+      {r => r}
+    )
+    def binaryDecoder(bytes: Array[Byte]): Int = Xor.catchNonFatal(
+      BufferReader(bytes.take(4)).readInt
+    ).fold(
+      {l => throw new ElementDecodingFailure("INT", l)},
+      {r => r}
+    )
+    def nullDecoder(): Int =                     throw new NullDecodedFailure("INT")
+  }
+}

--- a/types/src/main/scala/roc/types/failures.scala
+++ b/types/src/main/scala/roc/types/failures.scala
@@ -1,0 +1,29 @@
+package roc
+package types
+
+import roc.postgresql.failures.Failure
+
+object failures {
+
+  final class BinaryDecodingUnsupportedFailure(unsupportedType: String) extends Failure {
+    final override def getMessage: String = 
+      s"Binary decoding of type $unsupportedType is currently unsupported."
+  }
+
+  final class TextDecodingUnsupportedFailure(unsupportedType: String) extends Failure {
+    final override def getMessage: String = 
+      s"Text decoding of type $unsupportedType is currently unsupported."
+  }
+
+  final class NullDecodedFailure(unsupportedType: String) extends Failure {
+    final override def getMessage: String = 
+      s"A NULL value was decoded for type $unsupportedType. Hint: use the Option[$unsupportedType] decoder, or ensure that Postgres cannot return NULL for the requested value."
+  }
+
+  final class ElementDecodingFailure(elementDescription: String, throwable: Throwable)
+    extends Failure {
+    final override def getMessage: String = 
+      s"Failure to decode $elementDescription. ${throwable.getMessage()}"
+  }
+
+}

--- a/types/src/test/scala/roc/types/DecodersSpec.scala
+++ b/types/src/test/scala/roc/types/DecodersSpec.scala
@@ -1,0 +1,82 @@
+package roc
+package types
+
+import org.scalacheck.Prop.forAll
+import org.specs2._
+import roc.types.failures._
+import roc.types.{decoders => Decoders}
+
+final class DecodersSpec extends Specification with ScalaCheck { def is = s2"""
+
+  StringDecoder
+    must return the correct String when Text Decoding a valid String               ${StringDecoder().testTextDecoding}
+    must return the correct String when Binary Decoding a valid String Byte Array  ${StringDecoder().testBinaryDecoding}
+    must throw a NullDecodedFailure when Null Decoding a String                    ${StringDecoder().testNullDecoding}
+
+  IntDecoder
+    must return the correct Int when Text Decoding a valid Int String                   ${IntDecoder().testValidTextDecoding}
+    must throw a ElementDecodingFailure when Text Decoding an Invalid Int String        ${IntDecoder().testInvalidTextDecoding}
+    must return the correct Int when Binary Decoding a valid Int Byte Array             ${IntDecoder().testValidByteDecoding}
+    must throw a ElementDecodingFailure when Binary Decoding an invalid Int Byte Array  ${IntDecoder().testInvalidByteDecoding}
+    must throw a NullDecodedFailure when Null Decoding an Int                           ${IntDecoder().testNullDecoding}
+
+  OptionDecoder
+    must return Some(A) when Text Decoding a valid A                       ${OptionDecoder().testValidTextDecoding}
+    must throw a ElementDecodingFailure when Text Decoding an invalid A    ${OptionDecoder().testInvalidTextDecoding}
+    must return Some(A) when Binary Decoding a valid A                     ${OptionDecoder().testValidBinaryDecoding}
+    must throw a ElementDecodingFailure when Binary Decoding an invalid A  ${OptionDecoder().testInvalidBinaryDecoding}
+    must return None when Null Decoding a valid A                          ${OptionDecoder().testNullDecoding}
+
+                                                                            """
+
+  case class StringDecoder() extends ScalaCheck {
+    val testTextDecoding = forAll { x: String =>
+      Decoders.stringElementDecoder.textDecoder(x) must_== x
+    }
+    val testBinaryDecoding = forAll { xs: Array[Byte] =>
+      val expected = xs.map(_.toChar).mkString
+      Decoders.stringElementDecoder.binaryDecoder(xs) must_== expected
+    }
+    val testNullDecoding = {
+      Decoders.stringElementDecoder.nullDecoder must throwA[NullDecodedFailure]
+    }
+  }
+
+  case class IntDecoder() extends generators.IntDecoderGen {
+    val testValidTextDecoding = forAll(genValidInt) { x: IntContainer =>
+      Decoders.intElementDecoder.textDecoder(x.strValue) must_== x.int
+    }
+    val testInvalidTextDecoding = forAll { s: String =>
+      Decoders.intElementDecoder.textDecoder(s) must throwA[ElementDecodingFailure]
+    }
+    val testValidByteDecoding = forAll(genValidIntBytes) { x: IntBytesContainer =>
+      Decoders.intElementDecoder.binaryDecoder(x.bytes) must_== x.int
+    }
+    val testInvalidByteDecoding = forAll(genInvalidIntBytes) { xs: Array[Byte] =>
+      Decoders.intElementDecoder.binaryDecoder(xs) must throwA[ElementDecodingFailure]
+    }
+    val testNullDecoding = {
+      Decoders.intElementDecoder.nullDecoder must throwA[NullDecodedFailure]
+    }
+  }
+
+  case class OptionDecoder() extends generators.OptionDecoderGen {
+    import roc.types.decoders._ 
+
+    val testValidTextDecoding = forAll(genValidInt) { x: IntContainer =>
+      Decoders.optionElementDecoder[Int].textDecoder(x.strValue) must_== Some(x.int)
+    }
+    val testInvalidTextDecoding = forAll { s: String =>
+      Decoders.optionElementDecoder[Int].textDecoder(s) must throwA[ElementDecodingFailure]
+    }
+    val testValidBinaryDecoding = forAll(genValidIntBytes) { x: IntBytesContainer =>
+      Decoders.optionElementDecoder[Int].binaryDecoder(x.bytes) must_== Some(x.int)
+    }
+    val testInvalidBinaryDecoding = forAll(genInvalidIntBytes) { xs: Array[Byte] =>
+      Decoders.optionElementDecoder[Int].binaryDecoder(xs) must throwA[ElementDecodingFailure]
+    }
+    val testNullDecoding = forAll { i: Int =>
+      Decoders.optionElementDecoder[Int].nullDecoder() must_== None
+    }
+  }
+}

--- a/types/src/test/scala/roc/types/FailureSpec.scala
+++ b/types/src/test/scala/roc/types/FailureSpec.scala
@@ -1,0 +1,43 @@
+package roc
+package types
+
+import org.scalacheck.Prop.forAll
+import org.specs2._
+import roc.types.failures._
+
+final class FailureSpec extends Specification with ScalaCheck { def is = s2"""
+
+  BinaryDecodingUnsupportedFailure
+    must have correct error message  $testBinaryDecodingFailureErrMsg
+
+  TextDecodingUnsupportedFailure
+    must have correct error message  $testTextDecodingFailureErrMsg
+
+  NullDecodedFailure
+    must have correct error message  $testNullDecodedFailureErrMsg
+
+  ElementDecodingFailure
+    must have correct error message $testElementDecodingFailureErrMsg
+                                                                           """
+
+  val testBinaryDecodingFailureErrMsg = forAll { s: String =>
+    val failure = new BinaryDecodingUnsupportedFailure(s)
+    failure.getMessage() must_== s"Binary decoding of type $s is currently unsupported."
+  }
+
+  val testTextDecodingFailureErrMsg = forAll { s: String =>
+    val failure = new TextDecodingUnsupportedFailure(s)
+    failure.getMessage() must_== s"Text decoding of type $s is currently unsupported."
+  }
+
+  val testNullDecodedFailureErrMsg = forAll { s: String =>
+    val failure = new NullDecodedFailure(s)
+    failure.getMessage() must_== 
+      s"A NULL value was decoded for type $s. Hint: use the Option[$s] decoder, or ensure that Postgres cannot return NULL for the requested value."
+  }
+
+  val testElementDecodingFailureErrMsg = forAll { (s: String, t: Throwable) =>
+    val failure = new ElementDecodingFailure(s, t)
+    failure.getMessage() must_== s"Failure to decode $s. ${t.getMessage()}"
+  }
+}

--- a/types/src/test/scala/roc/types/generators.scala
+++ b/types/src/test/scala/roc/types/generators.scala
@@ -1,0 +1,43 @@
+package roc
+package types
+
+import java.nio.charset.StandardCharsets
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2._
+import roc.postgresql.transport.BufferWriter
+import roc.types.failures._
+import roc.types.{decoders => Decoders}
+
+object generators {
+
+  abstract class IntDecoderGen extends ScalaCheck {
+    protected lazy val genValidInt: Gen[IntContainer] = for {
+      int   <-  arbitrary[Int]
+    } yield new IntContainer(int, int.toString)
+    case class IntContainer(int: Int, strValue: String)
+
+    protected lazy val genValidIntBytes: Gen[IntBytesContainer] = for {
+      int   <-  arbitrary[Int]
+    } yield {
+      val bw = BufferWriter(new Array[Byte](4))
+      bw.writeInt(int)
+      new IntBytesContainer(int, bw.toBytes)
+    }
+    case class IntBytesContainer(int: Int, bytes: Array[Byte])
+
+    protected lazy val genInvalidIntBytes: Gen[Array[Byte]] = for {
+      length    <-  Gen.oneOf(0,1,2,3)
+      byte      <-  arbitrary[Byte]
+    } yield Array.fill(length)(byte)
+  }
+
+  def lengthOfCStyleString(s: String): Int = {
+    val bytes = s.getBytes(StandardCharsets.UTF_8)
+    bytes.length + 1
+  }
+
+  abstract class OptionDecoderGen extends IntDecoderGen
+}


### PR DESCRIPTION
The roc-types submodule is designed to for two purposes:

1. Hold standard Element Decoders
2. Hold Project defined types to allow custom implementations ( i.e., we
define one Json type that allows multiple JSON libraries to be used ).

This initial commit introduced a handful of Failures, as well as Decoders for String, Int, and Option[A].