### PR TITLE
Ci fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,8 +64,8 @@ lazy val roc = project.in(file("."))
   .settings(moduleName := "root")
   .settings(allSettings)
   .settings(docSettings)
-  .aggregate(core)
-  .dependsOn(core)
+  .aggregate(core, types)
+  .dependsOn(core, types)
 
 lazy val core =  project
   .settings(moduleName := "roc-core")

--- a/core/src/main/scala/roc/postgresql/transport/Buf.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Buf.scala
@@ -10,7 +10,7 @@ import java.nio.charset.{Charset, StandardCharsets}
   * @note As of this moment we are using Unpooled Buffers, but this may change in the near
   *     future.
   */
-private[roc] object Buf {
+object Buf {
 
   /** Creates a buf w/ the specified length
     * @length the capacity of the Buffer
@@ -50,7 +50,7 @@ private[roc] object Buf {
   * @args underlying a to utilize. 
   * @note unlike the existing Buffer, this is both read and write compatible
   */
-private[roc] final class Buf private(private[this] val underlying: ByteBuf) {
+final class Buf private(private[this] val underlying: ByteBuf) {
 
   /** Read one byte from the array
     * @returns Byte

--- a/core/src/test/scala/roc/postgresql/PostgresqlLexicalGen.scala
+++ b/core/src/test/scala/roc/postgresql/PostgresqlLexicalGen.scala
@@ -36,7 +36,10 @@ trait PostgresqlLexicalGen extends ScalaCheck {
   protected lazy val genValidSQLIdentifier: Gen[String] = for {
     firstChar   <-  genValidBeginningIdentifier
     chars       <-  Gen.listOf(genValidSubsequentIdentifier)
-  } yield (firstChar :: chars).foldLeft("")(_ + _)
+  } yield {
+    val xs = firstChar :: chars
+    xs.map(_.toString).reduce(_ + _)
+  }
 
   protected lazy val genValidNumberOfShortColumns: Gen[Short] = 
     Gen.chooseNum[Short](0, 1663) // the maximum number of Postgresql columns is 1663

--- a/core/src/test/scala/roc/postgresql/server/PostgresqlMessageSpec.scala
+++ b/core/src/test/scala/roc/postgresql/server/PostgresqlMessageSpec.scala
@@ -382,9 +382,20 @@ final class PostgresqlMessageSpec extends Specification with ScalaCheck { def is
   }
 
   case class EM() extends ErrorNoticeGen {
-    val testMessage = forAll(errMsgAndRequiredFieldsGen) { xs: ErrorMessageAndRequiredFields =>
-      val expectedMessage = s"${xs.severity} - ${xs.message}. SQLSTATE: ${xs.code}."
-      xs.error.toString must_== expectedMessage
+    val testMessage = forAll(errMsgAndRequiredFieldsGen) { x: ErrorMessageAndRequiredFields =>
+      val xs = x.errorParams
+      val ys = List(("Detail: ", xs.detail), ("Hint: ", xs.hint), ("Position: ", xs.position), 
+        ("Internal Position: ", xs.internalPosition), ("Internal Query: ", xs.internalQuery),
+        ("Where: ", xs.where), ("Schema Name: ", xs.schemaName), ("Table Name: ", xs.tableName),
+        ("Column Name: ", xs.columnName), ("Data Type Name: ", xs.dataTypeName), ("Constaint Name: ",
+        xs.constraintName), ("File: ", xs.file), ("Line: ", xs.line), ("Routine: ", xs.routine))
+      val optString = ys.filter(_._2 != None)
+        .map(x => (x._1, x._2.getOrElse("")))
+        .foldLeft("")((x,y) => x + y._1 + y._2 + "\n")
+      val requiredString = s"${xs.severity} - ${xs.message}. SQLSTATE: ${xs.code}."
+
+      val expectedMessage = requiredString + "\n" + optString 
+      x.error.toString must_== expectedMessage
     }
   }
 }

--- a/core/src/test/scala/roc/postgresql/transport/PacketDecodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketDecodersSpec.scala
@@ -38,14 +38,14 @@ final class PacketDecodersSpec extends Specification with ScalaCheck { def is = 
     should return Xor.Left(ReadyForQueryDecodingFailure) when given an invalid Char ${RFQ().testInvalidChar}
     should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${RFQ().testInvalidPacket}
 
+  DataRow
+    should return Xor.Right(DataRow) when given a valid Packet                      ${DR().testValidPacket}
+    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${DR().testInvalidPacket}
+
   RowDescription
     should return Xor.Right(RowDescription) when given a valid Packet               ${RD().testValidPacket}
     should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${RD().testInvalidPacket}
     should have valid Message when decoding an unknown Format Code                  ${RD().testUnknownFormatCode}
-
-  DataRow
-    should return Xor.Right(DataRow) when given a valid Packet                      ${DR().testValidPacket}
-    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${DR().testInvalidPacket}
 
   AuthenticationMessages
     should return Xor.Right(AuthenticationMessage) when given a valid Message Int              ${AM().testValid}
@@ -56,6 +56,7 @@ final class PacketDecodersSpec extends Specification with ScalaCheck { def is = 
     must return Xor.Right(NoticeResponse(PostgresqlMessage)) when given a valid Packet             ${NR().test}
     must return Xor.Left(PostgresqlMessageDecodingFailure) when given an invalid PostgresqlMessage ${NR().testInvalid}
     must return Xor.Left(PacketDecodingFailure) when given an invalid Packet                       ${NR().testInvalidPacket}
+
                                                                                   """
 
   case class ErrorMsg() extends generators.ErrorNoticePacketGen {


### PR DESCRIPTION
Tesst involving Error / Notice Packet decoding were bugging out due to
Scalacheck's arbitrary Strings. Using the PostgresqlLexicalGen to
generate Postgresql Compliant Strings appears to have fixed or
dramatically reduced the failure rate.

RowDescriptionField and DataRow tests were fixed due to a mistaken yanked list.reverse.