### PR TITLE
Added Char Element Decoder.

### DIFF
--- a/types/src/main/scala/roc/types/decoders.scala
+++ b/types/src/main/scala/roc/types/decoders.scala
@@ -128,4 +128,16 @@ object decoders {
     )
     def nullDecoder: Boolean                       = throw new NullDecodedFailure("BOOLEAN")
   }
+
+  implicit val charElementDecoder: ElementDecoder[Char] = new ElementDecoder[Char] {
+    def textDecoder(text: String): Char         = Xor.catchNonFatal(text.head.toChar).fold(
+      {l => throw new ElementDecodingFailure("CHAR", l)},
+      {r => r}
+    )
+    def binaryDecoder(bytes: Array[Byte]): Char = Xor.catchNonFatal(bytes.head.toChar).fold(
+      {l => throw new ElementDecodingFailure("CHAR", l)},
+      {r => r}
+    )
+    def nullDecoder: Char                       = throw new NullDecodedFailure("CHAR")
+  }
 }


### PR DESCRIPTION
An Element Decoder for single byte Chars was added to the types project. This partially addresses #51 .

Note: Char refers to the Postgresql (C) definition of a Char as a single byte, not as any valid "rune" in a UTF encoded String.