### PR TITLE
Added Json Element Decoder.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,8 @@ lazy val testDependencies = Seq(
   "org.specs2"      %%  "specs2-scalacheck" %   specs2Version,
   "org.specs2"      %%  "specs2-junit"      %   specs2Version,
   "org.specs2"      %%  "specs2-mock"       %   specs2Version,
+  "io.circe"        %%  "circe-core"        %   "0.4.1",
+  "io.circe"        %%  "circe-generic"     %   "0.4.1",
   "io.netty"        %   "netty-buffer"      %   nettyVersion
 )
 
@@ -92,6 +94,7 @@ lazy val types = project
   .settings(
     libraryDependencies ++= Seq(
       "io.netty"        %   "netty-buffer"  %  nettyVersion,
+      "org.spire-math"  %%  "jawn-ast"      %  "0.8.4",
       "org.typelevel"   %%  "cats"          %   catsVersion
     )
   )

--- a/types/src/main/scala/roc/types/package.scala
+++ b/types/src/main/scala/roc/types/package.scala
@@ -1,0 +1,9 @@
+package roc
+
+import jawn.ast.JValue
+
+package object types {
+
+  type Json = JValue
+
+}

--- a/types/src/test/scala/roc/types/decoders/JsonDecoderSpec.scala
+++ b/types/src/test/scala/roc/types/decoders/JsonDecoderSpec.scala
@@ -1,0 +1,76 @@
+package roc
+package types
+
+import io.circe.generic.auto._
+import io.circe.syntax._
+import java.nio.charset.StandardCharsets
+import jawn.ast.JParser
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2.{ScalaCheck, Specification}
+import roc.types.failures.{ElementDecodingFailure, NullDecodedFailure}
+import roc.types.{decoders => Decoders}
+
+final class JsonDecoderSpec extends Specification with ScalaCheck { def is = s2"""
+
+  JsonDecoder
+    must correctly decode Text representation                              $testValidText
+    must throw a ElementDecodingFailure when Text decoding invalid Json    $testInvalidText
+    must correctly decode Binary representation                            $testValidBinary
+    must throw a ElementDecodingFailure when Binary decoding invalid Json  $testInvalidBinary
+    must throw a NullDecodedFailure when Null decoding Json                $testNullDecoding
+
+                                                                               """
+
+  private val testValidText = forAll { x: JsonContainer =>
+    Decoders.jsonElementDecoder.textDecoder(x.text) must_== x.json
+  }
+
+  private val testInvalidText = forAll { x: String =>
+    Decoders.jsonElementDecoder.textDecoder(x) must throwA[ElementDecodingFailure]
+  }
+
+  private val testValidBinary = forAll { x: BinaryJsonContainer =>
+    Decoders.jsonElementDecoder.binaryDecoder(x.binary) must_== x.json
+  }
+
+  private val testInvalidBinary = forAll { xs: Array[Byte] =>
+    Decoders.jsonElementDecoder.binaryDecoder(xs) must throwA[ElementDecodingFailure]
+  }
+
+  private val testNullDecoding = 
+    Decoders.jsonElementDecoder.nullDecoder must throwA[NullDecodedFailure]
+
+  case class JsonContainer(text: String, json: Json)
+  private lazy val genJsonContainer: Gen[JsonContainer] = for {
+    jObject <- arbitrary[JsonObject]
+  } yield {
+    val text = jObject.asJson.noSpaces
+    val json = JParser.parseUnsafe(text)
+    new JsonContainer(text, json)
+  }
+  private implicit lazy val arbitraryJsonContainer: Arbitrary[JsonContainer] = 
+    Arbitrary(genJsonContainer)
+
+  case class BinaryJsonContainer(binary: Array[Byte], json: Json)
+  private lazy val genBinaryJsonContainer: Gen[BinaryJsonContainer] = for {
+    jObject <- arbitrary[JsonObject]
+  } yield {
+    val text = jObject.asJson.noSpaces
+    val json = JParser.parseUnsafe(text)
+    val bytes = text.getBytes(StandardCharsets.UTF_8)
+    new BinaryJsonContainer(bytes, json)
+  }
+  private implicit lazy val arbitraryBinaryJsonContainer: Arbitrary[BinaryJsonContainer] =
+    Arbitrary(genBinaryJsonContainer)
+
+  case class JsonObject(name: String, first_names: List[String])
+
+  private lazy val genJsonObject: Gen[JsonObject] = for {
+    name <- arbitrary[String]
+    first_names <- arbitrary[List[String]]
+  } yield new JsonObject(name, first_names)
+  private implicit lazy val arbitraryJsonObject: Arbitrary[JsonObject] = 
+    Arbitrary(genJsonObject)
+}


### PR DESCRIPTION
An Element Decoder for JSON was added to the types project. This partially addresses #51 .

The [Jawn Project](https://github.com/non/jawn) was introduced to handle JSON. The [Postgresql JSON/JSONB data type](http://www.postgresql.org/docs/current/static/datatype-json.html) is a valid JSON object according to [RFC 7159](http://rfc7159.net/rfc7159). 

The Jawn project is a very lightweight project concerned with parsing Text and Binary data into Valid Json ASTs. It allows roc to be agnostic about JSON libraries while ensuring that the Json data type conforms
to actual Json.