### PR TITLE
Fixed Long Decoding test.

### DIFF
--- a/types/src/test/scala/roc/types/decoders/NumericDecodersSpec.scala
+++ b/types/src/test/scala/roc/types/decoders/NumericDecodersSpec.scala
@@ -162,7 +162,7 @@ final class NumericDecodersSpec extends Specification with ScalaCheck { def is =
       Decoders.longElementDecoder.binaryDecoder(xs) must throwA[ElementDecodingFailure]
     }
 
-    val testNullDecoding = Decoders.intElementDecoder.nullDecoder must throwA[NullDecodedFailure]
+    val testNullDecoding = Decoders.longElementDecoder.nullDecoder must throwA[NullDecodedFailure]
 
     /** testValidTextDecoding */
     protected case class LongStringContainer(long: Long, longString: String)


### PR DESCRIPTION
The NullDecoding test for Longs was incorrectly testing for ints ( copy/paste FTW? ). This has been fixed.