### PR TITLE
Prepared roc for 0.0.2 release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val baseSettings = Seq(
 
 lazy val allSettings = buildSettings ++ baseSettings 
 
-lazy val coreVersion = "0.0.2-SNAPSHOT"
+lazy val coreVersion = "0.0.2"
 
 lazy val catsVersion = "0.4.1"
 


### PR DESCRIPTION
To prepare for the 0.0.2 release, the README was updated to reflect the changes to roc-types, and the version number was bumped.