### PR TITLE
Fix binary decoders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# IntelliJ
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -107,12 +107,14 @@ lazy val types = project
     )
   )
   .dependsOn(core)
+  .dependsOn(core % "it->it")
 
 lazy val benchmark = project
   .settings(
     description := "roc-benchmark",
     moduleName := "roc-benchmark"
   )
+  .configs( IntegrationTest )
   .settings(allSettings:_*)
   .settings(noPublishSettings)
   .enablePlugins(JmhPlugin)

--- a/types/src/it/scala/roc/types/integrations/BinaryDecodersIntegrationSpec.scala
+++ b/types/src/it/scala/roc/types/integrations/BinaryDecodersIntegrationSpec.scala
@@ -1,0 +1,104 @@
+package roc.types.integrations
+
+import java.time._
+import java.time.temporal.{ChronoField, JulianFields}
+
+import org.scalacheck._
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Arbitrary.arbitrary
+import org.specs2._
+import roc.integrations.Client
+import roc.postgresql.{ElementDecoder, Request, Text}
+import com.twitter.util.Await
+import roc.types._
+import roc.types.decoders._
+import jawn.ast.{JNull, JParser, JValue}
+
+class BinaryDecodersIntegrationSpec extends Specification with Client with ScalaCheck {
+
+  //need a more sensible BigDecimal generator, because ScalaCheck goes crazy with it and we can't even stringify them
+  //this will be sufficient to test the decoder
+  implicit val arbBD: Arbitrary[BigDecimal] = Arbitrary(for {
+    precision <- Gen.choose(1, 32)
+    scale <- Gen.choose(-32, 32)
+    digits <- Gen.listOfN[Char](precision, Gen.numChar)
+  } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)))
+
+  implicit val arbCirce: Arbitrary[_root_.io.circe.Json] = JsonGenerators.arbJson
+  //arbitrary Json for Jawn
+  implicit val arbJson = Arbitrary[Json](Gen.resize(4, for {
+    circe <- arbitrary[_root_.io.circe.Json]
+  } yield JParser.parseFromString(circe.noSpaces).toOption.getOrElse(JNull)))
+
+  implicit val arbDate = Arbitrary[Date](for {
+    julian <- Gen.choose(1721060, 5373484)  //Postgres date parser doesn't like dates outside year range 0000-9999
+  } yield LocalDate.now().`with`(JulianFields.JULIAN_DAY, julian))
+
+  implicit val arbTime = Arbitrary[Time](for {
+    usec <- Gen.choose(0L, 24L * 60 * 60 * 1000000 - 1)
+  } yield LocalTime.ofNanoOfDay(usec * 1000))
+
+  implicit val arbTimestampTz = Arbitrary[TimestampWithTZ](for {
+    milli <- Gen.posNum[Long]
+  } yield ZonedDateTime.ofInstant(Instant.ofEpochMilli(milli), ZoneId.systemDefault()))
+
+  def is = sequential ^ s2"""
+  Decoders
+    must decode string from binary $testString
+    must decode short from binary $testShort
+    must decode int from binary $testInt
+    must decode long from binary $testLong
+    must decode float from binary $testFloat
+    must decode double from binary $testDouble
+    must decode numeric from binary $testNumeric
+    must decode boolean from binary $testBoolean
+    must decode json from binary $testJson
+    must decode jsonb from binary $testJsonb
+    must decode date from binary $testDate
+    must decode time from binary $testTime
+    must decode timestamptz from binary $testTimestampTz
+  """
+
+  def test[T : Arbitrary : ElementDecoder](
+    send: String,
+    typ: String,
+    toStr: T => String = (t: T) => t.toString,
+    tester: (T, T) => Boolean = (a: T, b: T) => a == b) = forAll {
+    (t: T) =>
+      //TODO: change this once prepared statements are available
+      val escaped = toStr(t).replaceAllLiterally("'", "\\'")
+      val query = s"SELECT $send('$escaped'::$typ) AS out"
+      val result = Await.result(Postgres.query(Request(query)))
+      val Text(name, oid, string) = result.head.get('out)
+      val bytes = string.stripPrefix("\\x").sliding(2,2).toArray.map(Integer.parseInt(_, 16)).map(_.toByte)
+      val out = implicitly[ElementDecoder[T]].binaryDecoder(bytes)
+      tester(t, out)
+  }
+
+  def testString = test[String]("textsend", "text")
+  def testShort = test[Short]("int2send", "int2")
+  def testInt = test[Int]("int4send", "int4")
+  def testLong = test[Long]("int8send", "int8")
+  def testFloat = test[Float]("float4send", "float4")
+  def testDouble = test[Double]("float8send", "float8")
+  def testNumeric = test[BigDecimal]("numeric_send", "numeric", _.bigDecimal.toPlainString)
+  def testBoolean = test[Boolean]("boolsend", "boolean")
+  def testJson = test[Json]("json_send", "json")
+  def testJsonb = test[Json]("jsonb_send", "jsonb")
+  def testDate = test[Date]("date_send", "date")
+  def testTime = test[Time]("time_send", "time")
+  def testTimestampTz = test[TimestampWithTZ](
+    "timestamptz_send",
+    "timestamptz",
+    ts => java.sql.Timestamp.from(ts.toInstant).toString,
+    (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)  //postgres only keeps microsecond precision
+  )
+
+  //disabled - test server might not have hstore extension
+  def testHstore = test[HStore]("hstore_send", "hstore", { strMap =>
+    strMap.map {
+      case (k, v) =>
+        s""""${k.replaceAllLiterally("\"", "\\\"")}"=>"${v.getOrElse("NULL").replaceAllLiterally("\"", "\\\"")}""""
+    }.mkString(",")
+  })
+}

--- a/types/src/it/scala/roc/types/integrations/JsonGenerators.scala
+++ b/types/src/it/scala/roc/types/integrations/JsonGenerators.scala
@@ -1,0 +1,39 @@
+package roc.types.integrations
+
+import io.circe.{Json, JsonObject}
+import io.circe.syntax._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.{Arbitrary, Gen}
+
+object JsonGenerators {
+
+  val genJsonScalarValue : Gen[Json] = Gen.oneOf(
+    arbitrary[Long] map (_.asJson),
+    Gen.choose(Int.MinValue.toDouble, Int.MaxValue.toDouble) map (_.asJson),  //avoid parsing craziness
+    Gen.alphaStr map Json.fromString,
+    arbitrary[Boolean] map Json.fromBoolean
+  )
+
+  def genJsonArray(genValue: Gen[Json]) = Gen.listOf(genValue).map(Json.arr(_:_*))
+
+  def genJsonObject(genValue: Gen[Json]) = Gen.nonEmptyMap(for {
+    keySize <- Gen.choose(10, 20)
+    key <- Gen.resize(keySize, Gen.nonEmptyListOf(Gen.alphaNumChar).map(_.mkString))
+    value <- genValue
+  } yield (key, value)) map JsonObject.fromMap map Json.fromJsonObject
+
+  def genJson(level: Int) : Gen[Json] = if(level == 0)
+    genJsonScalarValue
+  else Gen.oneOf(
+    genJsonScalarValue,
+    genJsonArray(genJson(level - 1)),
+    genJsonObject(genJson(level - 1)))
+
+  implicit val arbJson : Arbitrary[Json] = Arbitrary(for {
+    size <- Gen.size
+    level <- Gen.choose(0, size)
+    json <- genJson(level)
+  } yield json)
+
+
+}

--- a/types/src/main/scala/roc/types/package.scala
+++ b/types/src/main/scala/roc/types/package.scala
@@ -8,4 +8,5 @@ package object types {
   type Date = LocalDate
   type Time = LocalTime
   type TimestampWithTZ = ZonedDateTime
+  type HStore = Map[String, Option[String]]
 }

--- a/types/src/test/scala/roc/types/decoders/DateTimeDecodersSpec.scala
+++ b/types/src/test/scala/roc/types/decoders/DateTimeDecodersSpec.scala
@@ -19,22 +19,16 @@ final class DateTimeDecodersSpec extends Specification with ScalaCheck { def is 
   LocalDate
     must correctly decode Text representation                                      $testValidTextLocalDate
     must throw a ElementDecodingFailure when Text decoding an invalid LocalDate    $testInvalidTextLocalDate
-    must correctly decode Binary representation                                    $testValidBinaryLocalDate
-    must throw a ElementDecodingFailure when Binary decoding an invalid LocalDate  $testInvalidBinaryLocalDate
     must throw a NullDecodedFailure when Null decoding LocalDate                   $testLocalDateNullDecoding
 
   LocalTime
     must correctly decode Text representation                                      $testValidLocalTimeText
     must throw a ElementDecodingFailure when Text decoding an invalid LocalTime    $testInvalidLocalTimeText
-    must correctly decode Binary representation                                    $testValidLocalTimeBinary
-    must throw a ElementDecodingFailure when Binary decoding an invalid LocalTime  $testInvalidLocalTimeBinary
     must throw a NullDecodedFailure when Null decoding LocalDate                   $testLocalTimeNullDecoding
 
   ZonedDateTime
     must correctly decode Text representation                                         $testValidZonedDateTimeText
     must throw a ElementDecodingFailure when Text decoding an invalid ZonedDateTime   $testInvalidZonedDateTimeText
-    must correctly decode Binary representation                                       $testValidZonedDateTimeBinary
-    must throw a ElementDecodingFailure when Binary decoding an invalid ZonedDateTime $testInvalidZonedDateTimeBinary
     must throw a NullDecodedFailure when Null decoding LocalDate                      $testZonedDateTimeNullDecoding
                                                                                     """
 

--- a/types/src/test/scala/roc/types/decoders/DecodersSpec.scala
+++ b/types/src/test/scala/roc/types/decoders/DecodersSpec.scala
@@ -13,28 +13,21 @@ final class DecodersSpec extends Specification with ScalaCheck { def is = s2"""
 
   StringDecoder
     must return the correct String when Text Decoding a valid String               ${StringDecoder().testTextDecoding}
-    must return the correct String when Binary Decoding a valid String Byte Array  ${StringDecoder().testBinaryDecoding}
     must throw a NullDecodedFailure when Null Decoding a String                    ${StringDecoder().testNullDecoding}
 
   BooleanDecoder
     must return the correct Boolean when Text Decoding a valid Boolean String               ${BooleanDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when Text Decoding an Invalid Boolean String        ${BooleanDecoder().testInvalidTextDecoding}
-    must return the correct Boolean when Binary Decoding a valid Boolean Byte Array         ${BooleanDecoder().testValidByteDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid Boolean Byte Array  ${BooleanDecoder().testInvalidByteDecoding}
     must throw a NullDecodedFailure when Null Decoding an Boolean                           ${BooleanDecoder().testNullDecoding}
 
   OptionDecoder
     must return Some(A) when Text Decoding a valid A                       ${OptionDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when Text Decoding an invalid A    ${OptionDecoder().testInvalidTextDecoding}
-    must return Some(A) when Binary Decoding a valid A                     ${OptionDecoder().testValidBinaryDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid A  ${OptionDecoder().testInvalidBinaryDecoding}
     must return None when Null Decoding a valid A                          ${OptionDecoder().testNullDecoding}
 
   CharDecoder
     must return the correct Char when Text Decoding a valid String                   ${CharDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when Text Decoding an invalid String         ${CharDecoder().testInvalidTextDecoding}
-    must return the correct Char when Binary Decoding a valid Array[Byte]            ${CharDecoder().testValidBinaryDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid Array[Byte]  ${CharDecoder().testInvalidBinaryDecoding}
     must throw a NullDecodedFailure when Null Decoding a Char                        ${CharDecoder().testNullDecoding}
                                                                             """
 

--- a/types/src/test/scala/roc/types/decoders/NumericDecodersSpec.scala
+++ b/types/src/test/scala/roc/types/decoders/NumericDecodersSpec.scala
@@ -14,36 +14,26 @@ final class NumericDecodersSpec extends Specification with ScalaCheck { def is =
   Short Decoder
     must return the correct Short when Text Decoding a valid Short String                 ${ShortDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when TextDecoding an Invalid Short String         ${ShortDecoder().testInvalidTextDecoding}
-    must return the correct Short when Binary Decoding a valid Short Byte Array           ${ShortDecoder().testValidBinaryDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid Short Byte Array  ${ShortDecoder().testInvalidBinaryDecoding}
     must throw a NullDecodedFailure when Null Decoding a Short                            ${ShortDecoder().testNullDecoding}
 
   Int Decoder
     must return the correct Int when Text Decoding a valid Int String                   ${IntDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when Text Decoding an Invalid Int String        ${IntDecoder().testInvalidTextDecoding}
-    must return the correct Int when Binary Decoding a valid Int Byte Array             ${IntDecoder().testValidByteDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid Int Byte Array  ${IntDecoder().testInvalidByteDecoding}
     must throw a NullDecodedFailure when Null Decoding an Int                           ${IntDecoder().testNullDecoding}
 
   Long Decoder
     must return the correct Long when Text Decoding a valid Long String                  ${LongDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when Text Decoding an Invalid Long String        ${LongDecoder().testInvalidTextDecoding}
-    must return the correct Long when Binary Decoding a valid Long Byte Array            ${LongDecoder().testValidByteDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid Long Byte Array  ${LongDecoder().testInvalidByteDecoding}
     must throw a NullDecodedFailure when Null Decoding a Long                            ${LongDecoder().testNullDecoding}
 
   Float Decoder
     must return the correct Float when Text Decoding a valid Float String                 ${FloatDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when Text Decoding an Invalid Float String        ${FloatDecoder().testInvalidTextDecoding}
-    must return the correct Float when Binary Decoding a valid Float Byte Array           ${FloatDecoder().testValidByteDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid Float Byte Array  ${FloatDecoder().testInvalidByteDecoding}
     must throw a NullDecodedFailure when Null Decoding a Float                            ${FloatDecoder().testNullDecoding}
 
   Double Decoder
     must return the correct Double when Text Decoding a valid Double String                ${DoubleDecoder().testValidTextDecoding}
     must throw a ElementDecodingFailure when Text Decoding an Invalid Double String        ${DoubleDecoder().testInvalidTextDecoding}
-    must return the correct Double when Binary Decoding a valid Double Byte Array          ${DoubleDecoder().testValidByteDecoding}
-    must throw a ElementDecodingFailure when Binary Decoding an invalid Double Byte Array  ${DoubleDecoder().testInvalidByteDecoding}
     must throw a NullDecodedFailure when Null Decoding a Double                            ${DoubleDecoder().testNullDecoding}
                                                                             """
 


### PR DESCRIPTION
I did this because many of the binary decoders were incorrect.

- Remove existing binary decoder tests and replace with integration tests against postgres
  (To verify that they do actually decode the actual PG binary representation)
- Update existing binary decoders for date/timestamp/time, string, and json
- Add hstore decoder
- Add numeric decoder