### PR TITLE
Updated Library Dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,15 +57,15 @@ lazy val baseSettings = Seq(
 
 lazy val allSettings = buildSettings ++ baseSettings ++ Defaults.itSettings
 
-lazy val coreVersion = "0.0.4-SNAPSHOT"
+lazy val coreVersion = "0.0.4"
 
-lazy val catsVersion = "0.5.0"
+lazy val catsVersion = "0.6.0"
 
-lazy val finagleVersion = "6.35.0"
+lazy val finagleVersion = "6.36.0"
 
 lazy val nettyVersion = "4.0.36.Final"
 
-lazy val circeVersion = "0.4.1"
+lazy val circeVersion = "0.5.0-M2"
 
 lazy val jawnVersion = "0.8.4"
 

--- a/core/src/main/scala/roc/postgresql/Messages.scala
+++ b/core/src/main/scala/roc/postgresql/Messages.scala
@@ -1,7 +1,7 @@
 package roc
 package postgresql
 
-import algebra.Eq
+import cats.Eq
 import cats.data.Xor
 import cats.std.all._
 import cats.syntax.eq._


### PR DESCRIPTION
Roc version was pushed to 0.0.4. In addition, the following dependencies
were updated:

Finagle, 6.35.0 -> 6.36.0
Cats, 0.5.0 -> 0.6.0
Circe, 0.4.1 -> 0.5.0-M2